### PR TITLE
Fallback to the buses which are being registered

### DIFF
--- a/src/DependencyInjection/Tags.php
+++ b/src/DependencyInjection/Tags.php
@@ -5,6 +5,8 @@ namespace Lcobucci\Chimera\Bus\Tactician\DependencyInjection;
 
 interface Tags
 {
-    public const MIDDLEWARE = 'chimera.bus_middleware';
-    public const HANDLER    = 'chimera.bus_handler';
+    public const MIDDLEWARE      = 'chimera.bus_middleware';
+    public const HANDLER         = 'chimera.bus_handler';
+    public const COMMAND_HANDLER = 'chimera.command_handler';
+    public const QUERY_HANDLER   = 'chimera.query_handler';
 }


### PR DESCRIPTION
So that we can have packages that define middlewares and handlers for any registered command/query bus.