### PR TITLE
Give a guessable name for tactician services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "league/tactician-container": "^2.0",
-        "phpstan/phpstan": "^0.8",
+        "phpstan/phpstan": "^0.9",
+        "phpstan/phpstan-phpunit": "^0.9",
         "phpunit/phpunit": "^6.3",
         "squizlabs/php_codesniffer": "^3.1",
         "symfony/dependency-injection": "^3.3"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,5 @@
-parameters:
-    ignoreErrors:
-        # Ignore PHPUnit mock stuff
-        - '#but returns PHPUnit_Framework_MockObject_MockObject#'
-        - '#PHPUnit_Framework_MockObject_MockObject.* given#'
+includes:
+	- vendor/phpstan/phpstan-phpunit/extension.neon
 
-        # Ignore symfony/expression-language missing classes
-        - '#Symfony\\Component\\ExpressionLanguage\\ExpressionLanguage not found#'
+parameters:
+    ignoreErrors: []

--- a/src/DependencyInjection/RegisterServices.php
+++ b/src/DependencyInjection/RegisterServices.php
@@ -234,6 +234,7 @@ final class RegisterServices implements CompilerPassInterface
         array $middlewares
     ): void {
         $internalBus = $this->registerTacticianBus(
+            $this->commandBusId . '.inner',
             $container,
             $commandNameExtractor,
             $methodNameInflector,
@@ -259,6 +260,7 @@ final class RegisterServices implements CompilerPassInterface
         $middlewares[] = $this->registerReadModelConverter($container, $readModelConverter);
 
         $internalBus = $this->registerTacticianBus(
+            $this->queryBusId . '.inner',
             $container,
             $commandNameExtractor,
             $methodNameInflector,
@@ -285,14 +287,13 @@ final class RegisterServices implements CompilerPassInterface
     }
 
     private function registerTacticianBus(
+        string $id,
         ContainerBuilder $container,
         Reference $commandNameExtractor,
         Reference $methodNameInflector,
         array $handlers,
         array $middlewares
     ): Reference {
-        $id = uniqid('chimera.bus_internal.');
-
         $handlerMiddleware = $this->registerTacticianHandler(
             $container,
             $id,

--- a/tests/DependencyInjection/RegisterServicesTest.php
+++ b/tests/DependencyInjection/RegisterServicesTest.php
@@ -15,7 +15,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class RegisterServicesTest extends \PHPUnit\Framework\TestCase
 {
-    private const DEFAULT_MIDDLEWARES_PATTERN = '/^chimera\.(read_model_conversion|bus_internal)\..*(\.handler)?$/';
+    private const DEFAULT_MIDDLEWARES_PATTERN = '/^(chimera\.(read_model_conversion|bus_internal)\..*|'
+                                              . '.*\.inner\.handler)$/';
 
     private const COMMAND_BUS = 'command_bus';
     private const QUERY_BUS   = 'query_bus';


### PR DESCRIPTION
When handling things outside of the HTTP context, we might want to use tactician buses directly (since we don't need to deserialise the request data).

This PR makes it possible by postfixing the tactician services with `.inner`, so if you pass `command_bus` and `query_bus` to the compiler pass' constructor you will be able to **inject** the buses into your services using the ids `command_bus.inner` and `query_bus.inner`.